### PR TITLE
Update DBpedia URI

### DIFF
--- a/src/org/freeyourmetadata/ner/services/DBpediaSpotlight.java
+++ b/src/org/freeyourmetadata/ner/services/DBpediaSpotlight.java
@@ -17,7 +17,7 @@ import org.json.JSONObject;
  * @author Ruben Verborgh
  */
 public class DBpediaSpotlight extends NERServiceBase implements NERService {
-    private final static URI SERVICEBASEURL = createUri("http://spotlight.dbpedia.org/rest/annotate");
+    private final static URI SERVICEBASEURL = createUri("http://spotlight.sztaki.hu:2222/rest/annotate");
     private final static String[] SERVICESETTINGS = {};
     private final static String[] EXTRACTIONSETTINGS = { "Confidence", "Support" };
 


### PR DESCRIPTION
As per Twitter conversation at https://twitter.com/roszmar/status/697381281890484224 and documentation at https://github.com/dbpedia-spotlight/dbpedia-spotlight have updated the DBpedia Annotate API URI to use working version of DBPedia Spotlight
